### PR TITLE
Show phase timers with ms in GUI

### DIFF
--- a/Swarky.py
+++ b/Swarky.py
@@ -500,7 +500,7 @@ class _UIPhase:
     def __exit__(self, exc_type, exc, tb):
         elapsed_ms = int((time.perf_counter() - self.t0) * 1000)
         logging.info(f"{self.label} finita in {elapsed_ms} ms",
-                     extra={"ui": ("phase_done", elapsed_ms)})
+                     extra={"ui": ("phase_done", self.label, elapsed_ms)})
         return False
 
 def ui_phase(label: str) -> _UIPhase:


### PR DESCRIPTION
## Summary
- include the phase label with the `phase_done` UI event so the GUI can show what finished and how long it took
- update the GUI phase end handler to compute and display the elapsed milliseconds for the current phase

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d15965d7f883329b2dee06dfcb7de6