### PR TITLE
Abilita apertura con doppio click nella lista Plotter

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -379,7 +379,20 @@ class SwarkyApp:
         if not self._scan_plotter_disabled:
             self.refresh_plotter()
 
-    def _open_selected_plotter(self, _=None) -> None:
+    def _open_selected_plotter(self, event: Optional[tk.Event] = None) -> None:
+        index: Optional[int] = None
+        if event is not None:
+            try:
+                index = self.plotter_list.nearest(event.y)
+            except Exception:
+                index = None
+            if index is not None:
+                try:
+                    self.plotter_list.selection_clear(0, tk.END)
+                except Exception:
+                    pass
+                self.plotter_list.selection_set(index)
+
         sel = self.plotter_list.curselection()
         if not sel:
             return


### PR DESCRIPTION
## Summary
- garantito che il doppio click sugli elementi della lista Plotter selezioni la voce e apra il file corrispondente

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ee06e06964833292446e3cc1df9534